### PR TITLE
feat: CI/CD — Dockerfile, GitHub Actions, tests et déploiement Render

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,26 @@
+name: CI/CD — Build & Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout du code
+        uses: actions/checkout@v4
+
+      - name: Configuration de Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Installation des dépendances
+        run: pip install -r requirements.txt
+
+      - name: Déclenchement du déploiement Render
+        run: |
+          curl -X POST ${{ secrets.RENDER_DEPLOY_HOOK }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,12 @@ jobs:
       - name: Installation des dépendances
         run: pip install -r requirements.txt
 
+      - name: Installation de pytest
+        run: pip install pytest
+
+      - name: Lancement des tests
+        run: pytest tests/ -v
+
       - name: Déclenchement du déploiement Render
         run: |
           curl -X POST ${{ secrets.RENDER_DEPLOY_HOOK }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
 
 jobs:
   deploy:

--- a/.gitignore
+++ b/.gitignore
@@ -211,7 +211,6 @@ data/
 
 # Model artifacts (se regeneran con el pipeline)
 model/*.pkl
-model/*.joblib
 
 # Python
 __pycache__/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app/ ./app/
+COPY model/ ./model/
+
+EXPOSE 8501
+
+CMD ["streamlit", "run", "app/main.py", "--server.port=8501", "--server.address=0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ COPY model/ ./model/
 
 EXPOSE 8501
 
-CMD ["streamlit", "run", "app/main.py", "--server.port=8501", "--server.address=0.0.0.0"]
+CMD ["streamlit", "run", "app/app.py", "--server.port=8501", "--server.address=0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY app/ ./app/
 COPY model/ ./model/
+COPY outputs/ ./outputs/
 
 EXPOSE 8501
 

--- a/README.md
+++ b/README.md
@@ -23,3 +23,21 @@ pip install -r requirements.txt
 | feat/mlflow | [nombre] | Experiment tracking, registry |
 | feat/app | [nombre] | Streamlit UI |
 | feat/cicd | [nombre] | Docker, GitHub Actions, Render |
+
+## Déploiement
+
+### Prérequis
+- Compte [Render](https://render.com) connecté au repo GitHub
+- Secret `RENDER_DEPLOY_HOOK` configuré dans GitHub Actions
+
+### Lancer l'app en local avec Docker
+```bash
+docker build -t loan-default-mlops .
+docker run -p 8501:8501 loan-default-mlops
+```
+Accéder à l'app : http://localhost:8501
+
+### CI/CD
+Chaque push sur `main` déclenche automatiquement :
+1. Installation des dépendances
+2. Déploiement sur Render via Deploy Hook

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,15 @@
+# tests/test_app.py
+import pytest
+
+def test_imports():
+    """Vérifie que les dépendances principales sont installées."""
+    import sklearn
+    import pandas
+    import numpy
+    import mlflow
+    import streamlit
+
+def test_version_python():
+    """Vérifie que la version Python est compatible."""
+    import sys
+    assert sys.version_info >= (3, 11), "Python 3.11+ requis"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,4 +1,5 @@
 # tests/test_app.py
+from pathlib import Path
 import pytest
 
 def test_imports():
@@ -13,3 +14,18 @@ def test_version_python():
     """Vérifie que la version Python est compatible."""
     import sys
     assert sys.version_info >= (3, 11), "Python 3.11+ requis"
+
+def test_structure_projet():
+    """Vérifie que la structure du projet est correcte."""
+    from pathlib import Path
+    assert Path("Dockerfile").exists(), "Dockerfile manquant"
+    assert Path("requirements.txt").exists(), "requirements.txt manquant"
+    assert Path("app").exists(), "Dossier app/ manquant"
+    assert Path("model").exists(), "Dossier model/ manquant"
+
+def test_dockerfile_contenu():
+    """Vérifie que le Dockerfile est correctement configuré."""
+    contenu = Path("Dockerfile").read_text()
+    assert "python:3.11-slim" in contenu, "Image de base incorrecte"
+    assert "8501" in contenu, "Port Streamlit manquant"
+    assert "app.py" in contenu, "Point d'entrée manquant"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -29,3 +29,18 @@ def test_dockerfile_contenu():
     assert "python:3.11-slim" in contenu, "Image de base incorrecte"
     assert "8501" in contenu, "Port Streamlit manquant"
     assert "app.py" in contenu, "Point d'entrée manquant"
+
+def test_modele_prediction():
+    """Vérifie que le modèle charge et prédit correctement."""
+    import joblib
+    import numpy as np
+    from pathlib import Path
+
+    model_path = Path("model/best_model.joblib")
+    if not model_path.exists():
+        pytest.skip("Modèle non disponible — test ignoré jusqu'au merge feat/app")
+
+    modele = joblib.load(model_path)
+    X = np.array([[2, 5000, 8000, 45000, 3, 650, 0.18, 1.6]])
+    prediction = modele.predict(X)
+    assert prediction[0] in [0, 1]


### PR DESCRIPTION
## Changements
- `Dockerfile` : image python:3.11-slim, port 8501, point d'entrée app/app.py
- `.github/workflows/deploy.yml` : tests CI sur push main et pull_request + déploiement Render automatique
- `tests/test_app.py` : 4 tests structure + 1 test fonctionnel modèle (skip conditionnel)
- `requirements.txt` : ajout de pytest
- `README.md` : section déploiement documentée

## Tests en local
pytest tests/ -v → 4/4 passed 

## Notes
- Test fonctionnel modèle en skip jusqu'au merge de feat/app
- Déploiement Render fonctionnel après merge de feat/app
- Deploy Hook configuré via secret GitHub (RENDER_DEPLOY_HOOK)